### PR TITLE
Ignore local agent tooling directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Local agent/editor tooling
+.agents/
+.claude/
+.cursor/


### PR DESCRIPTION
## Summary
- Adds ignore rules for local agent/editor tooling directories.
- Prevents personal workflow files from being reintroduced after the history cleanup.

## Test plan
- Reviewed .gitignore diff.